### PR TITLE
Replace strpcy by strlcpy on String::concat which doesn't care of the length.

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -266,7 +266,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!cstr) return 0;
 	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
-	strcpy(buffer + len, cstr);
+	strlcpy(buffer + len, cstr, length);
 	len = newlen;
 	return 1;
 }


### PR DESCRIPTION
Many edge case can be caused by strcpy, cause length not is taked care.

Referenced issue:
#590